### PR TITLE
add `upload` / `exec` target

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -48,6 +48,16 @@ if get_systype() == "darwin_x86_64":
 target_bin = env.BuildProgram()
 
 #
+# Target: Execute binary
+#
+
+exec_action = env.VerboseAction(
+    "$SOURCE $PROGRAM_ARGS", "Executing $SOURCE")
+
+AlwaysBuild(env.Alias("exec", target_bin, exec_action))
+AlwaysBuild(env.Alias("upload", target_bin, exec_action))
+
+#
 # Target: Print binary size
 #
 


### PR DESCRIPTION
This PR adds a `upload` / `exec` target, so clicking `upload` in the VSCode IDE will build and run the program.

As requested by @ivankravets in https://github.com/platformio/platform-windows_x86/pull/6#issuecomment-2332459690.
